### PR TITLE
Disable sending private key to server

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -108,7 +108,7 @@ interface GeneratedProps {
 function Generated(props: GeneratedProps) {
   const shareLink = `${window.location.protocol}//${
     window.location.host
-  }/receive/?k=${base64url.encode(props.privateKey)}`;
+  }/receive#$${base64url.encode(props.privateKey)}`;
   const sendToKakaoFriend = () => {
     const content = {
       objectType: "text",

--- a/app/receive/page.tsx
+++ b/app/receive/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Web3 } from "web3";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { Suspense, Dispatch, SetStateAction, useState } from "react";
 import base64url from "base64url";
 
@@ -10,14 +10,16 @@ interface FromProps {
 
 const Form = (props: FromProps) => {
   const [actualAddress, setActualAddress] = useState("");
-  const searchParams = useSearchParams();
-  const encodedTmpPrivateKey = searchParams.get("k") || "";
-  const web3 = new Web3("https://public-en-baobab.klaytn.net"); //https://docs.klaytn.foundation/docs/build/tutorials/connecting-metamask/#connect-to-klaytn-baobab-network-testnet-
-  const router = useRouter();
 
   const transferToActualAddress = async () => {
-    props.setIsLoading(true);
     try {
+      props.setIsLoading(true);
+
+      const web3 = new Web3("https://public-en-baobab.klaytn.net"); //https://docs.klaytn.foundation/docs/build/tutorials/connecting-metamask/#connect-to-klaytn-baobab-network-testnet-
+      const router = useRouter();
+
+      const hashValue = window.location.hash;
+      const encodedTmpPrivateKey = hashValue.substring(2);
       if (encodedTmpPrivateKey == "") {
         throw Error("Can't get temp key from url");
       }

--- a/app/receive/page.tsx
+++ b/app/receive/page.tsx
@@ -1,23 +1,19 @@
 "use client";
 import { Web3 } from "web3";
 import { useRouter } from "next/navigation";
-import { Suspense, Dispatch, SetStateAction, useState } from "react";
+import { useState } from "react";
 import base64url from "base64url";
 
-interface FromProps {
-  setIsLoading: Dispatch<SetStateAction<boolean>>;
-}
-
-const Form = (props: FromProps) => {
+export default function Receive() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
   const [actualAddress, setActualAddress] = useState("");
 
   const transferToActualAddress = async () => {
     try {
-      props.setIsLoading(true);
+      setIsLoading(true);
 
       const web3 = new Web3("https://public-en-baobab.klaytn.net"); //https://docs.klaytn.foundation/docs/build/tutorials/connecting-metamask/#connect-to-klaytn-baobab-network-testnet-
-      const router = useRouter();
-
       const hashValue = window.location.hash;
       const encodedTmpPrivateKey = hashValue.substring(2);
       if (encodedTmpPrivateKey == "") {
@@ -45,37 +41,13 @@ const Form = (props: FromProps) => {
       alert(e);
     }
   };
+
   const handleChange = (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => {
     setActualAddress(e.target.value);
   };
 
-  return (
-    <>
-      <form>
-        <input
-          type="text"
-          className="block py-2.5 px-0 w-64 text-bg text-white bg-transparent border-0 border-b-2 border-gray-500 appearance-none focus:outline-none focus:ring-0 focus:border-white"
-          name="address"
-          placeholder="0x01234..."
-          value={actualAddress}
-          onChange={handleChange}
-        />
-      </form>
-      <button
-        type="button"
-        className="w-64 h-14 bg-kaia text-black text-bg leading-6 font-medium py-2 px-3 rounded-lg"
-        onClick={transferToActualAddress}
-      >
-        Receive KAIA
-      </button>
-    </>
-  );
-};
-
-export default function Receive() {
-  const [isLoading, setIsLoading] = useState(false);
   return (
     <>
       {isLoading && (
@@ -106,9 +78,21 @@ export default function Receive() {
         <div></div>
         <div></div>
         <h1 className="text-2xl font-bold">Input Your Address</h1>
-        <Suspense>
-          <Form setIsLoading={setIsLoading} />
-        </Suspense>
+        <input
+          type="text"
+          className="block py-2.5 px-0 w-64 text-bg text-white bg-transparent border-0 border-b-2 border-gray-500 appearance-none focus:outline-none focus:ring-0 focus:border-white"
+          name="address"
+          placeholder="0x01234..."
+          value={actualAddress}
+          onChange={handleChange}
+        />
+        <button
+          type="button"
+          className="w-64 h-14 bg-kaia text-black text-bg leading-6 font-medium py-2 px-3 rounded-lg"
+          onClick={transferToActualAddress}
+        >
+          Receive KAIA
+        </button>
         <div></div>
         <div></div>
       </main>


### PR DESCRIPTION
This PR fix a security issue about private key. Private key in a share link has been send to a server because it is a query parameter. This PR makes the private key a hash value not a query parameter not to send the private key to server.